### PR TITLE
Add option to generate uppercase or lowercase UUID.

### DIFF
--- a/plugin/nuuid.vim
+++ b/plugin/nuuid.vim
@@ -3,6 +3,10 @@ if exists('g:nuuid_loaded') && g:nuuid_loaded
 endif
 let g:nuuid_loaded = 1
 
+if !exists('g:nuuid_case')
+	let g:nuuid_case = "lower"
+endif
+
 " Make sure we have python
 if !has('python')
 	" finish
@@ -12,14 +16,20 @@ endif
 function! NuuidNewUuid()
   if executable('uuidgen')
       let l:new_uuid=system('uuidgen')[:-2]
-      return l:new_uuid
+      if g:nuid_case == "lower"
+        return tolower(l:new_uuid)
+      else
+        return toupper(l:new_uuid)
     else
 python << endpy
 import vim
 from uuid import uuid4
 vim.command("let l:new_uuid = '%s'"% str(uuid4()))
 endpy
-	return l:new_uuid
+  if g:nuid_case == "lower"
+    return tolower(l:new_uuid)
+  else
+    return toupper(l:new_uuid)
   endif
 endfunction
 

--- a/plugin/nuuid.vim
+++ b/plugin/nuuid.vim
@@ -16,7 +16,7 @@ endif
 function! NuuidNewUuid()
   if executable('uuidgen')
       let l:new_uuid=system('uuidgen')[:-2]
-      if g:nuid_case == "lower"
+      if g:nuuid_case == "lower"
         return tolower(l:new_uuid)
       else
         return toupper(l:new_uuid)
@@ -26,7 +26,7 @@ import vim
 from uuid import uuid4
 vim.command("let l:new_uuid = '%s'"% str(uuid4()))
 endpy
-  if g:nuid_case == "lower"
+  if g:nuuid_case == "lower"
     return tolower(l:new_uuid)
   else
     return toupper(l:new_uuid)

--- a/plugin/nuuid.vim
+++ b/plugin/nuuid.vim
@@ -15,21 +15,15 @@ endif
 " Use python to generate a new UUID
 function! NuuidNewUuid()
   if executable('uuidgen')
-      let l:new_uuid=system('uuidgen')[:-2]
-      if g:nuuid_case == "lower"
-        return tolower(l:new_uuid)
-      else
-        return toupper(l:new_uuid)
-    else
+    let l:new_uuid=system('uuidgen')[:-2]
+    return g:nuuid_case == "lower" ? tolower(l:new_uuid) : toupper(l:new_uuid)
+  else
 python << endpy
 import vim
 from uuid import uuid4
 vim.command("let l:new_uuid = '%s'"% str(uuid4()))
 endpy
-  if g:nuuid_case == "lower"
-    return tolower(l:new_uuid)
-  else
-    return toupper(l:new_uuid)
+    return g:nuuid_case == "lower" ? tolower(l:new_uuid) : toupper(l:new_uuid)
   endif
 endfunction
 


### PR DESCRIPTION
Depend on the OS, uuidgen may give different case. Users can get the case they prefer by setting g:nuuid_case = "lower" or "upper". The default is "lower".

