### PR TITLE
#4: Silence errors due to missing abbreviations on load.

### DIFF
--- a/plugin/nuuid.vim
+++ b/plugin/nuuid.vim
@@ -35,8 +35,8 @@ function! s:NuuidInsertAbbrev()
 endfunction
 
 function! s:NuuidInsertUnabbrev()
-	silent iunabbrev nuuid
-	silent iunabbrev nguid
+	silent! iunabbrev nuuid
+	silent! iunabbrev nguid
 	let g:nuuid_iabbrev = 0
 endfunction
 


### PR DESCRIPTION
Thanks for this plugin! Implemented a fix for #4 to show some additional appreciation. 😄 

The abbreviations provided by this plugin don't exist on load, so calling `iunabbrev` is a no-op - but it's a noisy no-op! Adding `!` after each `silent` ensures that error output from this unnecessary call will be suppressed.

Alternatively, we could remove `call s:NuuidInsertUnabbrev()` from line 55, but that may break functionality for someone else using the plugin.